### PR TITLE
Clear pressedTime after a successful barcode read

### DIFF
--- a/index.js
+++ b/index.js
@@ -70,6 +70,8 @@ const VueBarcodeScanner = {
           attributes.previousCode = attributes.barcode
           // clear textbox
           attributes.barcode = ''
+          // clear pressedTime
+          attributes.pressedTime = []
           // document.activeElement.value = ''
           if (attributes.setting.sound) {
             triggerSound()

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-barcode-scanner",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Barcode Scanner Plugin for Vue.js",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
If you have a barcode that has an even number of characters, with the trigger "Enter" this makes it an odd amount of characters. This means that at the end of a barcode read, `pressedTime` still includes the "Enter" key because it does not get cleared as there are not 2 elements in the `pressedTime` array. So when you read a second barcode the, first character's time is compared with "Enter" from the last read and it fails so the first character is not included in the barcode scan.

Hope that makes sense.