### PR TITLE
Non key13 ending sequences

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,13 +67,7 @@ let options = {
   soundSrc: '/static/sound.wav', // default is blank
   sensitivity: 300, // default is 100
   requiredAttr: true, // default is false
-  // when a control key in this list is encountered in a scan sequence,
-  // it will be replaced with <VControlSequence> tags for easy string replacement
   controlSequenceKeys: ['NumLock', 'Clear'], // default is null
-  // this will fire the callback defined in the component once
-  // `sensitivity` ms has elapsed after the last character in the
-  // sequence is sent from the scanner. 
-  // useful for scanners that don't end their sequenced with ENTER
   callbackAfterTimeout: true // default is false
 }
 
@@ -82,6 +76,8 @@ Vue.use(VueBarcodeScanner, options)
 ```
 
 * Please note that if "requiredAttr" set to "true" you need to specific some input field with "data-barcode" and then only this input response to scanner
+* `controlSequenceKeys`:  when a control key in this list is encountered in a scan sequence, it will be replaced with <VControlSequence> tags for easy string replacement
+* `callbackAfterTimeout`: this will fire the callback defined in the component once `sensitivity` ms has elapsed, following the last character in the barcode sequence. This is useful for scanners that don't end their sequences with ENTER and is backwards compatible with scanners that do.
 ----------------------------------------
 ## Methods
 ### init
@@ -151,7 +147,7 @@ In your component file (.vue) just for the component you need to listener for ba
     }
   }
 ```
-### Advanced
+### Advanced (using eventBus)
 ```javascript
   export default {
     data: () => ({

--- a/README.md
+++ b/README.md
@@ -67,9 +67,14 @@ let options = {
   soundSrc: '/static/sound.wav', // default is blank
   sensitivity: 300, // default is 100
   requiredAttr: true, // default is false
-  controlSequenceKeys: ['NumLock', 'Clear'] // default is null
   // when a control key in this list is encountered in a scan sequence,
   // it will be replaced with <VControlSequence> tags for easy string replacement
+  controlSequenceKeys: ['NumLock', 'Clear'], // default is null
+  // this will fire the callback defined in the component once
+  // `sensitivity` ms has elapsed after the last character in the
+  // sequence is sent from the scanner. 
+  // useful for scanners that don't end their sequenced with ENTER
+  callbackAfterTimeout: true // default is false
 }
 
 Vue.use(VueBarcodeScanner, options)

--- a/README.md
+++ b/README.md
@@ -66,7 +66,10 @@ let options = {
   sound: true, // default is false
   soundSrc: '/static/sound.wav', // default is blank
   sensitivity: 300, // default is 100
-  requiredAttr: true // default is false
+  requiredAttr: true, // default is false
+  controlSequenceKeys: ['NumLock', 'Clear'] // default is null
+  // when a control key in this list is encountered in a scan sequence,
+  // it will be replaced with <VControlSequence> tags for easy string replacement
 }
 
 Vue.use(VueBarcodeScanner, options)
@@ -80,8 +83,10 @@ Vue.use(VueBarcodeScanner, options)
 Init method use for add event listener (keypress) for the scanner.
 
 ```javascript
-this.$barcodeScanner.init(callbackFunction)
+this.$barcodeScanner.init(callbackFunction, options)
 ```
+
+`options` defaults to an empty object, `{}`, and can be safely ignored. See Advanced Usage for an example.
 
 ### destroy
 Destroy method is for remove the listener when it's unnecessary.
@@ -141,6 +146,39 @@ In your component file (.vue) just for the component you need to listener for ba
     }
   }
 ```
+### Advanced
+```javascript
+  export default {
+    data: () => ({
+      loading: false
+    }),
+    created () {
+      // Pass an options object with `eventBus: true` to receive an eventBus back
+      // which emits `start` and `finish` events
+      const eventBus = this.$barcodeScanner.init(this.onBarcodeScanned, { eventBus: true })
+      if (eventBus) {
+        eventBus.$on('start', () => { this.loading = true })
+        eventBus.$on('finish', () => { this.loading = false })
+      }
+    },
+    destroyed () {
+      // Remove listener when component is destroyed
+      this.$barcodeScanner.destroy()
+    },
+    methods: {
+      // Create callback function to receive barcode when the scanner is already done
+      onBarcodeScanned (barcode) {
+        console.log(barcode)
+        // do something...
+      },
+      // Reset to the last barcode before hitting enter (whatever anything in the input box)
+      resetBarcode () {
+        let barcode = this.$barcodeScanner.getPreviousCode()
+        // do something...
+      }
+    }
+  }
+  ```
 
 # Disclaimer
 

--- a/index.js
+++ b/index.js
@@ -219,6 +219,9 @@ const VueBarcodeScanner = {
           }
           attributes.timeout =
             attributes.setting.callbackAfterTimeout &&
+            // ensure there are characters in the buffer
+            // otherwise, the callback will always fire
+            attributes.barcode.length > 0 &&
             setTimeout(finishScanSequence, attributes.setting.scannerSensitivity)
 
           // scan and validate each character

--- a/index.js
+++ b/index.js
@@ -39,7 +39,7 @@ const VueBarcodeScanner = {
         //   1. Scan barcode
         //   2. Scanner sends sequence of characters to device. Final character is not ENTER
         //   3. After `setting.scannerSensitivity` ms elapses, `callback` is called
-        finishAfterTimeout: false
+        callbackAfterTimeout: false
       },
       callback: null,
       hasListener: false,
@@ -63,7 +63,7 @@ const VueBarcodeScanner = {
       attributes.setting.soundSrc = options.soundSrc || attributes.setting.soundSrc
       attributes.setting.scannerSensitivity = options.sensitivity || attributes.setting.scannerSensitivity
       attributes.setting.controlSequenceKeys = options.controlSequenceKeys || null
-      attributes.setting.finishAfterTimeout = options.finishAfterTimeout || false
+      attributes.setting.callbackAfterTimeout = options.callbackAfterTimeout || false
     }
 
     Vue.prototype.$barcodeScanner = {}
@@ -218,7 +218,7 @@ const VueBarcodeScanner = {
             clearTimeout(attributes.timeout)
           }
           attributes.timeout =
-            attributes.setting.finishAfterTimeout &&
+            attributes.setting.callbackAfterTimeout &&
             setTimeout(finishScanSequence, attributes.setting.scannerSensitivity)
 
           // scan and validate each character

--- a/index.js
+++ b/index.js
@@ -49,7 +49,7 @@ const VueBarcodeScanner = {
 
     Vue.prototype.$barcodeScanner = {}
 
-    Vue.prototype.$barcodeScanner.init = (callback, options) => {
+    Vue.prototype.$barcodeScanner.init = (callback, options = {}) => {
       // add listenter for scanner
       // use keypress to separate lower/upper case character from scanner
       addListener('keypress')

--- a/index.js
+++ b/index.js
@@ -9,11 +9,33 @@ const VueBarcodeScanner = {
         sound: false,
         soundSrc: '',
         scannerSensitivity: 100,
-        requiredAttr: false
+        requiredAttr: false,
+        // `controlSequenceKeys` should be an array of Strings ([String])
+        // that will be joined in a regex string for identifying
+        // control sequences
+        //
+        // they will be replaced in the return string by tags
+        // example:
+        //   NumLock, 0, 0, 1, 3, NumLock
+        //   is replaced with
+        //   <VControlSequence>0013</VControlSequence>
+        //
+        // this allows easy string replacement
+        controlSequenceKeys: null,
       },
       callback: null,
       hasListener: false,
-      pressedTime: []
+      pressedTime: [],
+      // This is used for scanners which do not send
+      // ENTER (13) as the final key code
+      // in a barcode sequence.
+      timeout: null,
+      // Used to handle control sequences
+      isInControlSequence: false,
+      // Used to emit messages
+      eventBus: null,
+      // Used for determing whether or not to emit a `start` event
+      isProcessing: false,
     }
 
     // initial plugin setting
@@ -22,17 +44,34 @@ const VueBarcodeScanner = {
       attributes.setting.sound = options.sound || attributes.setting.sound
       attributes.setting.soundSrc = options.soundSrc || attributes.setting.soundSrc
       attributes.setting.scannerSensitivity = options.sensitivity || attributes.setting.scannerSensitivity
+      attributes.setting.controlSequenceKeys = options.controlSequenceKeys || null
     }
 
     Vue.prototype.$barcodeScanner = {}
 
-    Vue.prototype.$barcodeScanner.init = (callback) => {
+    Vue.prototype.$barcodeScanner.init = (callback, options) => {
       // add listenter for scanner
       // use keypress to separate lower/upper case character from scanner
       addListener('keypress')
       // use keydown only to detect Tab event (Tab cannot be detected using keypress)
       addListener('keydown')
       attributes.callback = callback
+
+      // allow an event bus to be passed back to the caller
+      //
+      // this is an `init` option because whomever is implementing
+      // this plugin may not want to create additional Vue instances
+      // on every component, but would like to have access to a bus
+      // under some circumstances
+      //
+      // the importance of this is greater when scanning 2D
+      // barcodes, which take significantly longer (>=4 seconds)
+      // than 1D barcodes and some kind of indication of
+      // what the library is doing is useful
+      if (options.eventBus) {
+        attributes.eventBus = new Vue()
+        return attributes.eventBus
+      }
     }
 
     Vue.prototype.$barcodeScanner.destroy = () => {
@@ -46,7 +85,7 @@ const VueBarcodeScanner = {
     }
 
     Vue.prototype.$barcodeScanner.getPreviousCode = () => {
-       return attributes.previousCode
+      return attributes.previousCode
     }
 
     Vue.prototype.$barcodeScanner.setSensitivity = (sensitivity) => {
@@ -68,13 +107,78 @@ const VueBarcodeScanner = {
       }
     }
 
+    // this is called when either an ENTER key (13) is received
+    // or when the `attributes.timeout` fires, following
+    // a scan sequence
+    function finishScanSequence () {
+      // clear and null the timeout
+      if (attributes.timeout) {
+        clearTimeout(attributes.timeout)
+      }
+      attributes.timeout = null
+
+      // scanner is done and trigger Enter/Tab then clear barcode and play the sound if it's set as true
+      attributes.callback(attributes.barcode)
+      // backup the barcode
+      attributes.previousCode = attributes.barcode
+      // clear textbox
+      attributes.barcode = ''
+      // clear pressedTime
+      attributes.pressedTime = []
+      // trigger sound
+      if (attributes.setting.sound) {
+        triggerSound()
+      }
+      emitEvent("finish")
+      attributes.isProcessing = false
+    }
+
+    // if entering a control sequence, add `<VControlSequence>` to the buffer
+    // if exiting a control sequence, add `</VControlSequence>` to the buffer
+    // toggle control sequence flag
+    function handleControlBoundaryKeydown () {
+      attributes.barcode += attributes.isInControlSequence
+        ? "</VControlSequence>"
+        : "<VControlSequence>"
+
+      attributes.isInControlSequence = !attributes.isInControlSequence
+    }
+
+    // Returns a regex or null
+    function controlSequenceRegex () {
+      if (attributes.setting.controlSequenceKeys) {
+        return new RegExp(attributes.setting.controlSequenceKeys.join("|"))
+      }
+      return null
+    }
+
+    function emitEvent (type, payload) {
+      if (attributes.eventBus) {
+        attributes.eventBus.$emit(type, payload)
+      }
+    }
+
     function onInputScanned (event) {
+      const controlRegex = controlSequenceRegex()
+
       // ignore other keydown event that is not a TAB, so there are no duplicate keys
-      if (event.type === 'keydown' && event.keyCode != 9 ) {
-        return
+      if (event.type === 'keydown' && event.keyCode != 9) {
+        // Return early if this is not a control key that should be observed
+        if (controlRegex && !controlRegex.test(event.key)) return
+        // Return early if no control keys should be observed
+        if (!controlRegex) return
+      }
+
+      // handle control boundary keydown
+      if (event.type === 'keydown' && controlRegex && controlRegex.test(event.key)) {
+        return handleControlBoundaryKeydown()
       }
 
       if (checkInputElapsedTime(Date.now())) {
+        if (!attributes.isProcessing) {
+          emitEvent("start", event)
+          attributes.isProcessing = true
+        }
         // check if field has 'data-barcode' attribute
         let barcodeIdentifier = false
         if (attributes.setting.requiredAttr) {
@@ -83,24 +187,20 @@ const VueBarcodeScanner = {
           barcodeIdentifier = true
         }
         if (barcodeIdentifier && (event.keyCode === 13 || event.keyCode === 9) && attributes.barcode !== '') {
-          // scanner is done and trigger Enter/Tab then clear barcode and play the sound if it's set as true
-          attributes.callback(attributes.barcode)
-          // backup the barcode
-          attributes.previousCode = attributes.barcode
-          // clear textbox
-          attributes.barcode = ''
-          // clear pressedTime
-          attributes.pressedTime = []
-          // trigger sound
-          if (attributes.setting.sound) {
-            triggerSound()
-          }
+          finishScanSequence()
+
           // prevent TAB navigation for scanner
           if (event.keyCode === 9) {
             event.preventDefault()
           }
         } else {
-          // scan and validate each charactor
+          // reset the finish sequence timer and add the key to the buffer
+          if (attributes.timeout) {
+            clearTimeout(attributes.timeout)
+          }
+          attributes.timeout = setTimeout(finishScanSequence, attributes.setting.scannerSensitivity)
+
+          // scan and validate each character
           attributes.barcode += event.key
         }
       }

--- a/index.js
+++ b/index.js
@@ -22,6 +22,24 @@ const VueBarcodeScanner = {
         //
         // this allows easy string replacement
         controlSequenceKeys: null,
+        // Some scanners do not end their sequence with the ENTER key.
+        // This option allows "finishing" the sequence without an ENTER key
+        // after the number of ms defined in `setting.scannerSensitivity`
+        // elapses after the last character in the sequence.
+        // Example:
+        // (without timeout, sequence ends with ENTER):
+        //   1. Scan barcode
+        //   2. Scanner sends sequence of characters to device, ending with ENTER (13) key
+        //   3. `callback` passed in `init()` is called
+        // (without timeout, sequence ends without ENTER):
+        //   1. Scan barcode
+        //   2. Scanner sends sequence of characters to device. Final character is not ENTER
+        //   3. `callback` is not called until the ENTER key is pressed
+        // (with timeout, sequence ends without ENTER):
+        //   1. Scan barcode
+        //   2. Scanner sends sequence of characters to device. Final character is not ENTER
+        //   3. After `setting.scannerSensitivity` ms elapses, `callback` is called
+        finishAfterTimeout: false
       },
       callback: null,
       hasListener: false,
@@ -198,7 +216,9 @@ const VueBarcodeScanner = {
           if (attributes.timeout) {
             clearTimeout(attributes.timeout)
           }
-          attributes.timeout = setTimeout(finishScanSequence, attributes.setting.scannerSensitivity)
+          attributes.timeout =
+            attributes.setting.finishAfterTimeout &&
+            setTimeout(finishScanSequence, attributes.setting.scannerSensitivity)
 
           // scan and validate each character
           attributes.barcode += event.key

--- a/index.js
+++ b/index.js
@@ -63,6 +63,7 @@ const VueBarcodeScanner = {
       attributes.setting.soundSrc = options.soundSrc || attributes.setting.soundSrc
       attributes.setting.scannerSensitivity = options.sensitivity || attributes.setting.scannerSensitivity
       attributes.setting.controlSequenceKeys = options.controlSequenceKeys || null
+      attributes.setting.finishAfterTimeout = options.finishAfterTimeout || false
     }
 
     Vue.prototype.$barcodeScanner = {}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-barcode-scanner",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Barcode Scanner Plugin for Vue.js",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
# Summary
This PR adds three things:

1. A plugin option (`callbackAfterTimeout`) that, when set to `true`, will fire a component's callback<sup>1</sup> after `scannerSensitivity` ms has elapsed following the final character in a scanner barcode sequence
2. A plugin option (`controlSequenceKeys`) that accepts an array of strings. When a key in this list is encountered in a scanner barcode sequence, it will be replaced with `<VControlSequence>` tags, to make string replacement easy
3. An `init` function option (`eventBus`) that, when set to `true`, will return an eventBus. When a scanner barcode sequence begins, a `start` event will be emitted on the bus. When a scanner barcode sequence ends, a `finish` event will be emitted on the bus.

All changes are backward compatible and should not affect any current implementations. I have updated the README with examples and descriptions of new options.

# Notes
1. This is useful for scanners that do not send `ENTER` as the final character in their sequences. Also, this is backward compatible, as an `ENTER` key will also fire the callback, clearing the timeout.