### PR TITLE
Added compatibility for vue3

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 const VueBarcodeScanner = {
-  install (Vue, options) {
+  install (vue, options) {
     /* global Audio */
     // default plugin setting
     let attributes = {
@@ -66,9 +66,9 @@ const VueBarcodeScanner = {
       attributes.setting.callbackAfterTimeout = options.callbackAfterTimeout || false
     }
 
-    Vue.prototype.$barcodeScanner = {}
+    vue.config.globalProperties.$barcodeScanner = {}
 
-    Vue.prototype.$barcodeScanner.init = (callback, options = {}) => {
+    vue.config.globalProperties.$barcodeScanner.init = (callback, options = {}) => {
       // add listenter for scanner
       // use keypress to separate lower/upper case character from scanner
       addListener('keypress')
@@ -93,21 +93,21 @@ const VueBarcodeScanner = {
       }
     }
 
-    Vue.prototype.$barcodeScanner.destroy = () => {
+    vue.config.globalProperties.$barcodeScanner.destroy = () => {
       // remove listener
       removeListener('keypress')
       removeListener('keydown')
     }
 
-    Vue.prototype.$barcodeScanner.hasListener = () => {
+    vue.config.globalProperties.$barcodeScanner.hasListener = () => {
       return attributes.hasListener
     }
 
-    Vue.prototype.$barcodeScanner.getPreviousCode = () => {
+    vue.config.globalProperties.$barcodeScanner.getPreviousCode = () => {
       return attributes.previousCode
     }
 
-    Vue.prototype.$barcodeScanner.setSensitivity = (sensitivity) => {
+    vue.config.globalProperties.$barcodeScanner.setSensitivity = (sensitivity) => {
       attributes.setting.scannerSensitivity = sensitivity
     }
 


### PR DESCRIPTION
In 2.x, it was possible to inject globally shared instance properties by simply attaching them to Vue.prototype.

In Vue 3, since the global Vue is no longer a constructor, this is no longer supported. Instead, shared instance properties should be attached to an app instance's config.globalProperties instead:
```
// Before
Vue.prototype.$http = () => {}

// After
const app = createApp()
app.config.globalProperties.$http = () => {}
```